### PR TITLE
Let Docker manage the Postgres data volume 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         environment:
             - POSTGRES_PASSWORD=password
         volumes:
-            - ./postgres_local_data:/var/lib/postgresql/data
+            - /var/lib/postgresql/data
             - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     django:
         build: ../WA-back-end


### PR DESCRIPTION
Docker Compose has trouble setting up local folder paths as Docker volumes on Windows machines. 

In order to fix this, I removed the local file path in the volume definition and allowed Docker to fully manage the location of the created volume